### PR TITLE
Log latest processed block on error

### DIFF
--- a/geyser-plugin-runner/src/main.rs
+++ b/geyser-plugin-runner/src/main.rs
@@ -20,7 +20,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     let file = std::fs::File::open(file_path)?;
     let reader = BufReader::with_capacity(8 * 1024 * 1024, file);
     let mut item_index = 0;
-    {
+    
+    // Track the latest processed block number
+    let mut latest_processed_block_number: Option<u64> = None;
+    
+    // Wrap the main processing logic to catch errors and print block number
+    let result = {
         let mut reader = node::NodeReader::new(reader)?;
         let header = reader.read_raw_header()?;
         println!("Header bytes: {:?}", header);
@@ -55,202 +60,242 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         let mut todo_previous_blockhash = solana_hash::Hash::default();
         let mut todo_latest_entry_blockhash = solana_hash::Hash::default();
+        
         loop {
-            let nodes = reader.read_until_block()?;
-            // println!("Nodes: {:?}", nodes.get_cids());
-            let block = nodes.get_block()?;
-            // println!("Slot: {:?}", block.slot);
-            // println!("Raw node: {:?}", raw_node);
-            let mut entry_index: usize = 0;
-            let mut this_block_executed_transaction_count: u64 = 0;
-            let mut this_block_entry_count: u64 = 0;
-            let mut this_block_rewards: solana_storage_proto::convert::generated::Rewards =
-                solana_storage_proto::convert::generated::Rewards::default();
-
-            if block.slot % 1000 == 0 {
-                println!("___ Processing Block: {:?}", block.slot);
+            match process_block(&mut reader, &mut latest_processed_block_number, &mut item_index, &transaction_notifier, &entry_notifier_maybe, &block_meta_notifier_maybe, &confirmed_bank_sender, &mut todo_previous_blockhash, &mut todo_latest_entry_blockhash) {
+                Ok(_) => continue,
+                Err(e) => return Err(e),
             }
-
-            nodes.each(|node_with_cid| -> Result<(), Box<dyn Error>> {
-                item_index += 1;
-                let node = node_with_cid.get_node();
-
-                match node {
-                    node::Node::Transaction(transaction) => {
-                        let parsed = transaction.as_parsed()?;
-
-                        {
-                            let reassembled_metadata =
-                                nodes.reassemble_dataframes(transaction.metadata.clone())?;
-
-                            let decompressed = utils::decompress_zstd(reassembled_metadata.clone())?;
-
-                            let metadata: solana_storage_proto::convert::generated::TransactionStatusMeta =
-                                prost_011::Message::decode(decompressed.as_slice()).map_err(|err| {
-                                    Box::new(std::io::Error::new(
-                                        std::io::ErrorKind::Other,
-                                        std::format!("Error decoding metadata: {:?}", err),
-                                    ))
-                                })?;
-
-
-                            let as_native_metadata: solana_transaction_status::TransactionStatusMeta =
-                                metadata.try_into()?;
-
-                           {
-                                // TODO: test address loading.
-                                let dummy_address_loader = MessageAddressLoaderFromTxMeta::new(as_native_metadata.clone());
-                                let sanitized_tx = match  parsed.version() {
-                                    solana_transaction::versioned::TransactionVersion::Number(_)=> {
-                                        let message_hash = parsed.verify_and_hash_message()?;
-                                        let versioned_sanitized_tx= solana_transaction::versioned::sanitized::SanitizedVersionedTransaction::try_from(parsed)?;
-                                        solana_transaction::sanitized::SanitizedTransaction::try_new(
-                                            versioned_sanitized_tx,
-                                            message_hash,
-                                            false,
-                                            dummy_address_loader,
-                                            &HashSet::default(),
-                                        )
-                                    },
-                                    solana_transaction::versioned::TransactionVersion::Legacy(_legacy)=> {
-                                        solana_transaction::sanitized::SanitizedTransaction::try_from_legacy_transaction(
-                                            parsed.into_legacy_transaction().unwrap(),
-                                            &HashSet::default(),
-                                        )
-                                    },
-                                };
-                                if sanitized_tx.is_err() {
-                                    panic!(
-                                        "Failed to create SanitizedTransaction, error: {:?}",
-                                        sanitized_tx.err()
-                                    );
-                                }
-                                let sanitized_tx = sanitized_tx.unwrap();
-
-                                transaction_notifier
-                                        .notify_transaction(
-                                            block.slot,
-                                            transaction.index.unwrap() as usize,
-                                            sanitized_tx.signature(),
-                                            &as_native_metadata,
-                                            &sanitized_tx,
-                                        );
-                            }
-                        }
-
-                        // if parsed.version()
-                        //     == solana_transaction::versioned::TransactionVersion::Number(0)
-                        // {
-                        //     return Ok(());
-                        // }
-                    }
-                    node::Node::Entry(_entry) => {
-                        todo_latest_entry_blockhash = solana_hash::Hash::from(_entry.hash.to_bytes());
-                        this_block_executed_transaction_count += _entry.transactions.len() as u64;
-                        this_block_entry_count += 1;
-                        if entry_notifier_maybe.is_none() {
-                            return Ok(());
-                        }
-                        let entry_notifier = entry_notifier_maybe.as_ref().unwrap();
-                        // println!("___ Entry: {:?}", entry);
-                        let entry_summary=solana_entry::entry::EntrySummary {
-                            num_hashes: _entry.num_hashes,
-                            hash: solana_hash::Hash::from(_entry.hash.to_bytes()),
-                            num_transactions: _entry.transactions.len() as u64,
-                        };
-
-                        let starting_transaction_index = 0; // TODO:: implement this
-                        entry_notifier
-                            .notify_entry(block.slot, entry_index  ,&entry_summary, starting_transaction_index);
-                        entry_index+=1;
-                    }
-                    node::Node::Block(_block) => {
-                        // println!("___ Block: {:?}", block);
-                        let notification = SlotNotification::Root((block.slot, block.meta.parent_slot));
-                        confirmed_bank_sender.send(notification).unwrap();
-
-                        {
-                            if block_meta_notifier_maybe.is_none() {
-                                return Ok(());
-                            }
-                            let mut keyed_rewards = Vec::with_capacity(this_block_rewards.rewards.len());
-                            {
-                                // convert this_block_rewards to rewards
-                                for this_block_reward in this_block_rewards.rewards.iter() {
-                                    let reward: RewardInfo = RewardInfo{
-                                        reward_type: match this_block_reward.reward_type {
-                                            0 => RewardType::Fee,
-                                            1 => RewardType::Rent,
-                                            2 => RewardType::Staking,
-                                            3 => RewardType::Voting,
-                                            _ => panic!("___ not supported reward type"),
-                                        },
-                                        lamports: this_block_reward.lamports,
-                                        post_balance: this_block_reward.post_balance,
-                                        // commission is Option<u8> , but this_block_reward.commission is string
-                                        commission: match this_block_reward.commission.parse::<u8>() {
-                                            Ok(commission) => Some(commission),
-                                            Err(_err) => None,
-                                        },
-                                    };
-                                    keyed_rewards.push((solana_pubkey::Pubkey::from_str(&this_block_reward.pubkey)?, reward));
-                                }
-                            }
-                            // if keyed_rewards.read().unwrap().len() > 0 {
-                            //   panic!("___ Rewards: {:?}", keyed_rewards.read().unwrap());
-                            // }
-                            let block_meta_notifier = block_meta_notifier_maybe.as_ref().unwrap();
-                            block_meta_notifier
-                                .notify_block_metadata(
-                                    block.meta.parent_slot,
-                                    todo_previous_blockhash.to_string().as_str(),
-                                    block.slot,
-                                    todo_latest_entry_blockhash.to_string().as_str(),
-                                    &KeyedRewardsAndNumPartitions {
-                                        keyed_rewards,
-                                        num_partitions: None
-                                    },
-                                    Some(block.meta.blocktime as i64) ,
-                                    block.meta.block_height,
-                                    this_block_executed_transaction_count,
-                                    this_block_entry_count,
-                                );
-                        }
-                        todo_previous_blockhash = todo_latest_entry_blockhash;
-                    }
-                    node::Node::Subset(_subset) => {
-                        // println!("___ Subset: {:?}", subset);
-                    }
-                    node::Node::Epoch(epoch) => {
-                        println!("___ Epoch: {:?}", epoch);
-                    }
-                    node::Node::Rewards(rewards) => {
-                        // println!("___ Rewards: {:?}", node_with_cid.get_cid());
-                        // println!("___ Next items: {:?}", rewards.data.next);
-
-                        #[allow(clippy::overly_complex_bool_expr)]
-                        if !rewards.is_complete() && false {
-                            let reassembled = nodes.reassemble_dataframes(rewards.data.clone())?;
-                            println!("___ reassembled: {:?}", reassembled.len());
-
-                            let decompressed = utils::decompress_zstd(reassembled)?;
-
-                            this_block_rewards = prost_011::Message::decode(decompressed.as_slice()).map_err(|err| {
-                                Box::new(std::io::Error::new(
-                                    std::io::ErrorKind::Other,
-                                    std::format!("Error decoding rewards: {:?}", err),
-                                ))
-                            })?;
-                        }
-                    }
-                    node::Node::DataFrame(_) => {
-                        // println!("___ DataFrame: {:?}", node_with_cid.get_cid());
-                    }
-                }
-                Ok(())
-            })?;
+        }
+    };
+    
+    // If there was an error, print the latest processed block number before exiting
+    if let Err(ref error) = result {
+        match latest_processed_block_number {
+            Some(block_num) => {
+                eprintln!("ERROR: Failed to process node from file. Latest processed block number: {}", block_num);
+                eprintln!("Error details: {}", error);
+            }
+            None => {
+                eprintln!("ERROR: Failed to process node from file. No blocks were successfully processed yet.");
+                eprintln!("Error details: {}", error);
+            }
         }
     }
+    
+    result
+}
+
+fn process_block(
+    reader: &mut node::NodeReader<BufReader<std::fs::File>>,
+    latest_processed_block_number: &mut Option<u64>,
+    item_index: &mut usize,
+    transaction_notifier: &solana_geyser_plugin_manager::transaction_notifier::TransactionNotifier,
+    entry_notifier_maybe: &Option<solana_geyser_plugin_manager::entry_notifier::EntryNotifier>,
+    block_meta_notifier_maybe: &Option<solana_geyser_plugin_manager::block_metadata_notifier::BlockMetadataNotifier>,
+    confirmed_bank_sender: &crossbeam_channel::Sender<SlotNotification>,
+    todo_previous_blockhash: &mut solana_hash::Hash,
+    todo_latest_entry_blockhash: &mut solana_hash::Hash,
+) -> Result<(), Box<dyn Error>> {
+    let nodes = reader.read_until_block()?;
+    // println!("Nodes: {:?}", nodes.get_cids());
+    let block = nodes.get_block()?;
+    
+    // Update the latest processed block number
+    *latest_processed_block_number = Some(block.slot);
+    
+    // println!("Slot: {:?}", block.slot);
+    // println!("Raw node: {:?}", raw_node);
+    let mut entry_index: usize = 0;
+    let mut this_block_executed_transaction_count: u64 = 0;
+    let mut this_block_entry_count: u64 = 0;
+    let mut this_block_rewards: solana_storage_proto::convert::generated::Rewards =
+        solana_storage_proto::convert::generated::Rewards::default();
+
+    if block.slot % 1000 == 0 {
+        println!("___ Processing Block: {:?}", block.slot);
+    }
+
+    nodes.each(|node_with_cid| -> Result<(), Box<dyn Error>> {
+        *item_index += 1;
+        let node = node_with_cid.get_node();
+
+        match node {
+            node::Node::Transaction(transaction) => {
+                let parsed = transaction.as_parsed()?;
+
+                {
+                    let reassembled_metadata =
+                        nodes.reassemble_dataframes(transaction.metadata.clone())?;
+
+                    let decompressed = utils::decompress_zstd(reassembled_metadata.clone())?;
+
+                    let metadata: solana_storage_proto::convert::generated::TransactionStatusMeta =
+                        prost_011::Message::decode(decompressed.as_slice()).map_err(|err| {
+                            Box::new(std::io::Error::new(
+                                std::io::ErrorKind::Other,
+                                std::format!("Error decoding metadata: {:?}", err),
+                            ))
+                        })?;
+
+
+                    let as_native_metadata: solana_transaction_status::TransactionStatusMeta =
+                        metadata.try_into()?;
+
+                   {
+                        // TODO: test address loading.
+                        let dummy_address_loader = MessageAddressLoaderFromTxMeta::new(as_native_metadata.clone());
+                        let sanitized_tx = match  parsed.version() {
+                            solana_transaction::versioned::TransactionVersion::Number(_)=> {
+                                let message_hash = parsed.verify_and_hash_message()?;
+                                let versioned_sanitized_tx= solana_transaction::versioned::sanitized::SanitizedVersionedTransaction::try_from(parsed)?;
+                                solana_transaction::sanitized::SanitizedTransaction::try_new(
+                                    versioned_sanitized_tx,
+                                    message_hash,
+                                    false,
+                                    dummy_address_loader,
+                                    &HashSet::default(),
+                                )
+                            },
+                            solana_transaction::versioned::TransactionVersion::Legacy(_legacy)=> {
+                                solana_transaction::sanitized::SanitizedTransaction::try_from_legacy_transaction(
+                                    parsed.into_legacy_transaction().unwrap(),
+                                    &HashSet::default(),
+                                )
+                            },
+                        };
+                        if sanitized_tx.is_err() {
+                            panic!(
+                                "Failed to create SanitizedTransaction, error: {:?}",
+                                sanitized_tx.err()
+                            );
+                        }
+                        let sanitized_tx = sanitized_tx.unwrap();
+
+                        transaction_notifier
+                                .notify_transaction(
+                                    block.slot,
+                                    transaction.index.unwrap() as usize,
+                                    sanitized_tx.signature(),
+                                    &as_native_metadata,
+                                    &sanitized_tx,
+                                );
+                    }
+                }
+
+                // if parsed.version()
+                //     == solana_transaction::versioned::TransactionVersion::Number(0)
+                // {
+                //     return Ok(());
+                // }
+            }
+            node::Node::Entry(_entry) => {
+                *todo_latest_entry_blockhash = solana_hash::Hash::from(_entry.hash.to_bytes());
+                this_block_executed_transaction_count += _entry.transactions.len() as u64;
+                this_block_entry_count += 1;
+                if entry_notifier_maybe.is_none() {
+                    return Ok(());
+                }
+                let entry_notifier = entry_notifier_maybe.as_ref().unwrap();
+                // println!("___ Entry: {:?}", entry);
+                let entry_summary=solana_entry::entry::EntrySummary {
+                    num_hashes: _entry.num_hashes,
+                    hash: solana_hash::Hash::from(_entry.hash.to_bytes()),
+                    num_transactions: _entry.transactions.len() as u64,
+                };
+
+                let starting_transaction_index = 0; // TODO:: implement this
+                entry_notifier
+                    .notify_entry(block.slot, entry_index  ,&entry_summary, starting_transaction_index);
+                entry_index+=1;
+            }
+            node::Node::Block(_block) => {
+                // println!("___ Block: {:?}", block);
+                let notification = SlotNotification::Root((block.slot, block.meta.parent_slot));
+                confirmed_bank_sender.send(notification).unwrap();
+
+                {
+                    if block_meta_notifier_maybe.is_none() {
+                        return Ok(());
+                    }
+                    let mut keyed_rewards = Vec::with_capacity(this_block_rewards.rewards.len());
+                    {
+                        // convert this_block_rewards to rewards
+                        for this_block_reward in this_block_rewards.rewards.iter() {
+                            let reward: RewardInfo = RewardInfo{
+                                reward_type: match this_block_reward.reward_type {
+                                    0 => RewardType::Fee,
+                                    1 => RewardType::Rent,
+                                    2 => RewardType::Staking,
+                                    3 => RewardType::Voting,
+                                    _ => panic!("___ not supported reward type"),
+                                },
+                                lamports: this_block_reward.lamports,
+                                post_balance: this_block_reward.post_balance,
+                                // commission is Option<u8> , but this_block_reward.commission is string
+                                commission: match this_block_reward.commission.parse::<u8>() {
+                                    Ok(commission) => Some(commission),
+                                    Err(_err) => None,
+                                },
+                            };
+                            keyed_rewards.push((solana_pubkey::Pubkey::from_str(&this_block_reward.pubkey)?, reward));
+                        }
+                    }
+                    // if keyed_rewards.read().unwrap().len() > 0 {
+                    //   panic!("___ Rewards: {:?}", keyed_rewards.read().unwrap());
+                    // }
+                    let block_meta_notifier = block_meta_notifier_maybe.as_ref().unwrap();
+                    block_meta_notifier
+                        .notify_block_metadata(
+                            block.meta.parent_slot,
+                            todo_previous_blockhash.to_string().as_str(),
+                            block.slot,
+                            todo_latest_entry_blockhash.to_string().as_str(),
+                            &KeyedRewardsAndNumPartitions {
+                                keyed_rewards,
+                                num_partitions: None
+                            },
+                            Some(block.meta.blocktime as i64) ,
+                            block.meta.block_height,
+                            this_block_executed_transaction_count,
+                            this_block_entry_count,
+                        );
+                }
+                *todo_previous_blockhash = *todo_latest_entry_blockhash;
+            }
+            node::Node::Subset(_subset) => {
+                // println!("___ Subset: {:?}", subset);
+            }
+            node::Node::Epoch(epoch) => {
+                println!("___ Epoch: {:?}", epoch);
+            }
+            node::Node::Rewards(rewards) => {
+                // println!("___ Rewards: {:?}", node_with_cid.get_cid());
+                // println!("___ Next items: {:?}", rewards.data.next);
+
+                #[allow(clippy::overly_complex_bool_expr)]
+                if !rewards.is_complete() && false {
+                    let reassembled = nodes.reassemble_dataframes(rewards.data.clone())?;
+                    println!("___ reassembled: {:?}", reassembled.len());
+
+                    let decompressed = utils::decompress_zstd(reassembled)?;
+
+                    this_block_rewards = prost_011::Message::decode(decompressed.as_slice()).map_err(|err| {
+                        Box::new(std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            std::format!("Error decoding rewards: {:?}", err),
+                        ))
+                    })?;
+                }
+            }
+            node::Node::DataFrame(_) => {
+                // println!("___ DataFrame: {:?}", node_with_cid.get_cid());
+            }
+        }
+        Ok(())
+    })?;
+    
+    Ok(())
 }
 
 pub struct MessageAddressLoaderFromTxMeta {

--- a/geyser-plugin-runner/src/main.rs
+++ b/geyser-plugin-runner/src/main.rs
@@ -60,12 +60,204 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         let mut todo_previous_blockhash = solana_hash::Hash::default();
         let mut todo_latest_entry_blockhash = solana_hash::Hash::default();
-        
         loop {
-            match process_block(&mut reader, &mut latest_processed_block_number, &mut item_index, &transaction_notifier, &entry_notifier_maybe, &block_meta_notifier_maybe, &confirmed_bank_sender, &mut todo_previous_blockhash, &mut todo_latest_entry_blockhash) {
-                Ok(_) => continue,
-                Err(e) => return Err(e),
+            let nodes = reader.read_until_block()?;
+            // println!("Nodes: {:?}", nodes.get_cids());
+            let block = nodes.get_block()?;
+            
+            // Update the latest processed block number
+            latest_processed_block_number = Some(block.slot);
+            
+            // println!("Slot: {:?}", block.slot);
+            // println!("Raw node: {:?}", raw_node);
+            let mut entry_index: usize = 0;
+            let mut this_block_executed_transaction_count: u64 = 0;
+            let mut this_block_entry_count: u64 = 0;
+            let mut this_block_rewards: solana_storage_proto::convert::generated::Rewards =
+                solana_storage_proto::convert::generated::Rewards::default();
+
+            if block.slot % 1000 == 0 {
+                println!("___ Processing Block: {:?}", block.slot);
             }
+
+            nodes.each(|node_with_cid| -> Result<(), Box<dyn Error>> {
+                item_index += 1;
+                let node = node_with_cid.get_node();
+
+                match node {
+                    node::Node::Transaction(transaction) => {
+                        let parsed = transaction.as_parsed()?;
+
+                        {
+                            let reassembled_metadata =
+                                nodes.reassemble_dataframes(transaction.metadata.clone())?;
+
+                            let decompressed = utils::decompress_zstd(reassembled_metadata.clone())?;
+
+                            let metadata: solana_storage_proto::convert::generated::TransactionStatusMeta =
+                                prost_011::Message::decode(decompressed.as_slice()).map_err(|err| {
+                                    Box::new(std::io::Error::new(
+                                        std::io::ErrorKind::Other,
+                                        std::format!("Error decoding metadata: {:?}", err),
+                                    ))
+                                })?;
+
+
+                            let as_native_metadata: solana_transaction_status::TransactionStatusMeta =
+                                metadata.try_into()?;
+
+                           {
+                                // TODO: test address loading.
+                                let dummy_address_loader = MessageAddressLoaderFromTxMeta::new(as_native_metadata.clone());
+                                let sanitized_tx = match  parsed.version() {
+                                    solana_transaction::versioned::TransactionVersion::Number(_)=> {
+                                        let message_hash = parsed.verify_and_hash_message()?;
+                                        let versioned_sanitized_tx= solana_transaction::versioned::sanitized::SanitizedVersionedTransaction::try_from(parsed)?;
+                                        solana_transaction::sanitized::SanitizedTransaction::try_new(
+                                            versioned_sanitized_tx,
+                                            message_hash,
+                                            false,
+                                            dummy_address_loader,
+                                            &HashSet::default(),
+                                        )
+                                    },
+                                    solana_transaction::versioned::TransactionVersion::Legacy(_legacy)=> {
+                                        solana_transaction::sanitized::SanitizedTransaction::try_from_legacy_transaction(
+                                            parsed.into_legacy_transaction().unwrap(),
+                                            &HashSet::default(),
+                                        )
+                                    },
+                                };
+                                if sanitized_tx.is_err() {
+                                    panic!(
+                                        "Failed to create SanitizedTransaction, error: {:?}",
+                                        sanitized_tx.err()
+                                    );
+                                }
+                                let sanitized_tx = sanitized_tx.unwrap();
+
+                                transaction_notifier
+                                        .notify_transaction(
+                                            block.slot,
+                                            transaction.index.unwrap() as usize,
+                                            sanitized_tx.signature(),
+                                            &as_native_metadata,
+                                            &sanitized_tx,
+                                        );
+                            }
+                        }
+
+                        // if parsed.version()
+                        //     == solana_transaction::versioned::TransactionVersion::Number(0)
+                        // {
+                        //     return Ok(());
+                        // }
+                    }
+                    node::Node::Entry(_entry) => {
+                        todo_latest_entry_blockhash = solana_hash::Hash::from(_entry.hash.to_bytes());
+                        this_block_executed_transaction_count += _entry.transactions.len() as u64;
+                        this_block_entry_count += 1;
+                        if entry_notifier_maybe.is_none() {
+                            return Ok(());
+                        }
+                        let entry_notifier = entry_notifier_maybe.as_ref().unwrap();
+                        // println!("___ Entry: {:?}", entry);
+                        let entry_summary=solana_entry::entry::EntrySummary {
+                            num_hashes: _entry.num_hashes,
+                            hash: solana_hash::Hash::from(_entry.hash.to_bytes()),
+                            num_transactions: _entry.transactions.len() as u64,
+                        };
+
+                        let starting_transaction_index = 0; // TODO:: implement this
+                        entry_notifier
+                            .notify_entry(block.slot, entry_index  ,&entry_summary, starting_transaction_index);
+                        entry_index+=1;
+                    }
+                    node::Node::Block(_block) => {
+                        // println!("___ Block: {:?}", block);
+                        let notification = SlotNotification::Root((block.slot, block.meta.parent_slot));
+                        confirmed_bank_sender.send(notification).unwrap();
+
+                        {
+                            if block_meta_notifier_maybe.is_none() {
+                                return Ok(());
+                            }
+                            let mut keyed_rewards = Vec::with_capacity(this_block_rewards.rewards.len());
+                            {
+                                // convert this_block_rewards to rewards
+                                for this_block_reward in this_block_rewards.rewards.iter() {
+                                    let reward: RewardInfo = RewardInfo{
+                                        reward_type: match this_block_reward.reward_type {
+                                            0 => RewardType::Fee,
+                                            1 => RewardType::Rent,
+                                            2 => RewardType::Staking,
+                                            3 => RewardType::Voting,
+                                            _ => panic!("___ not supported reward type"),
+                                        },
+                                        lamports: this_block_reward.lamports,
+                                        post_balance: this_block_reward.post_balance,
+                                        // commission is Option<u8> , but this_block_reward.commission is string
+                                        commission: match this_block_reward.commission.parse::<u8>() {
+                                            Ok(commission) => Some(commission),
+                                            Err(_err) => None,
+                                        },
+                                    };
+                                    keyed_rewards.push((solana_pubkey::Pubkey::from_str(&this_block_reward.pubkey)?, reward));
+                                }
+                            }
+                            // if keyed_rewards.read().unwrap().len() > 0 {
+                            //   panic!("___ Rewards: {:?}", keyed_rewards.read().unwrap());
+                            // }
+                            let block_meta_notifier = block_meta_notifier_maybe.as_ref().unwrap();
+                            block_meta_notifier
+                                .notify_block_metadata(
+                                    block.meta.parent_slot,
+                                    todo_previous_blockhash.to_string().as_str(),
+                                    block.slot,
+                                    todo_latest_entry_blockhash.to_string().as_str(),
+                                    &KeyedRewardsAndNumPartitions {
+                                        keyed_rewards,
+                                        num_partitions: None
+                                    },
+                                    Some(block.meta.blocktime as i64) ,
+                                    block.meta.block_height,
+                                    this_block_executed_transaction_count,
+                                    this_block_entry_count,
+                                );
+                        }
+                        todo_previous_blockhash = todo_latest_entry_blockhash;
+                    }
+                    node::Node::Subset(_subset) => {
+                        // println!("___ Subset: {:?}", subset);
+                    }
+                    node::Node::Epoch(epoch) => {
+                        println!("___ Epoch: {:?}", epoch);
+                    }
+                    node::Node::Rewards(rewards) => {
+                        // println!("___ Rewards: {:?}", node_with_cid.get_cid());
+                        // println!("___ Next items: {:?}", rewards.data.next);
+
+                        #[allow(clippy::overly_complex_bool_expr)]
+                        if !rewards.is_complete() && false {
+                            let reassembled = nodes.reassemble_dataframes(rewards.data.clone())?;
+                            println!("___ reassembled: {:?}", reassembled.len());
+
+                            let decompressed = utils::decompress_zstd(reassembled)?;
+
+                            this_block_rewards = prost_011::Message::decode(decompressed.as_slice()).map_err(|err| {
+                                Box::new(std::io::Error::new(
+                                    std::io::ErrorKind::Other,
+                                    std::format!("Error decoding rewards: {:?}", err),
+                                ))
+                            })?;
+                        }
+                    }
+                    node::Node::DataFrame(_) => {
+                        // println!("___ DataFrame: {:?}", node_with_cid.get_cid());
+                    }
+                }
+                Ok(())
+            })?;
         }
     };
     
@@ -84,218 +276,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
     
     result
-}
-
-fn process_block(
-    reader: &mut node::NodeReader<BufReader<std::fs::File>>,
-    latest_processed_block_number: &mut Option<u64>,
-    item_index: &mut usize,
-    transaction_notifier: &solana_geyser_plugin_manager::transaction_notifier::TransactionNotifier,
-    entry_notifier_maybe: &Option<solana_geyser_plugin_manager::entry_notifier::EntryNotifier>,
-    block_meta_notifier_maybe: &Option<solana_geyser_plugin_manager::block_metadata_notifier::BlockMetadataNotifier>,
-    confirmed_bank_sender: &crossbeam_channel::Sender<SlotNotification>,
-    todo_previous_blockhash: &mut solana_hash::Hash,
-    todo_latest_entry_blockhash: &mut solana_hash::Hash,
-) -> Result<(), Box<dyn Error>> {
-    let nodes = reader.read_until_block()?;
-    // println!("Nodes: {:?}", nodes.get_cids());
-    let block = nodes.get_block()?;
-    
-    // Update the latest processed block number
-    *latest_processed_block_number = Some(block.slot);
-    
-    // println!("Slot: {:?}", block.slot);
-    // println!("Raw node: {:?}", raw_node);
-    let mut entry_index: usize = 0;
-    let mut this_block_executed_transaction_count: u64 = 0;
-    let mut this_block_entry_count: u64 = 0;
-    let mut this_block_rewards: solana_storage_proto::convert::generated::Rewards =
-        solana_storage_proto::convert::generated::Rewards::default();
-
-    if block.slot % 1000 == 0 {
-        println!("___ Processing Block: {:?}", block.slot);
-    }
-
-    nodes.each(|node_with_cid| -> Result<(), Box<dyn Error>> {
-        *item_index += 1;
-        let node = node_with_cid.get_node();
-
-        match node {
-            node::Node::Transaction(transaction) => {
-                let parsed = transaction.as_parsed()?;
-
-                {
-                    let reassembled_metadata =
-                        nodes.reassemble_dataframes(transaction.metadata.clone())?;
-
-                    let decompressed = utils::decompress_zstd(reassembled_metadata.clone())?;
-
-                    let metadata: solana_storage_proto::convert::generated::TransactionStatusMeta =
-                        prost_011::Message::decode(decompressed.as_slice()).map_err(|err| {
-                            Box::new(std::io::Error::new(
-                                std::io::ErrorKind::Other,
-                                std::format!("Error decoding metadata: {:?}", err),
-                            ))
-                        })?;
-
-
-                    let as_native_metadata: solana_transaction_status::TransactionStatusMeta =
-                        metadata.try_into()?;
-
-                   {
-                        // TODO: test address loading.
-                        let dummy_address_loader = MessageAddressLoaderFromTxMeta::new(as_native_metadata.clone());
-                        let sanitized_tx = match  parsed.version() {
-                            solana_transaction::versioned::TransactionVersion::Number(_)=> {
-                                let message_hash = parsed.verify_and_hash_message()?;
-                                let versioned_sanitized_tx= solana_transaction::versioned::sanitized::SanitizedVersionedTransaction::try_from(parsed)?;
-                                solana_transaction::sanitized::SanitizedTransaction::try_new(
-                                    versioned_sanitized_tx,
-                                    message_hash,
-                                    false,
-                                    dummy_address_loader,
-                                    &HashSet::default(),
-                                )
-                            },
-                            solana_transaction::versioned::TransactionVersion::Legacy(_legacy)=> {
-                                solana_transaction::sanitized::SanitizedTransaction::try_from_legacy_transaction(
-                                    parsed.into_legacy_transaction().unwrap(),
-                                    &HashSet::default(),
-                                )
-                            },
-                        };
-                        if sanitized_tx.is_err() {
-                            panic!(
-                                "Failed to create SanitizedTransaction, error: {:?}",
-                                sanitized_tx.err()
-                            );
-                        }
-                        let sanitized_tx = sanitized_tx.unwrap();
-
-                        transaction_notifier
-                                .notify_transaction(
-                                    block.slot,
-                                    transaction.index.unwrap() as usize,
-                                    sanitized_tx.signature(),
-                                    &as_native_metadata,
-                                    &sanitized_tx,
-                                );
-                    }
-                }
-
-                // if parsed.version()
-                //     == solana_transaction::versioned::TransactionVersion::Number(0)
-                // {
-                //     return Ok(());
-                // }
-            }
-            node::Node::Entry(_entry) => {
-                *todo_latest_entry_blockhash = solana_hash::Hash::from(_entry.hash.to_bytes());
-                this_block_executed_transaction_count += _entry.transactions.len() as u64;
-                this_block_entry_count += 1;
-                if entry_notifier_maybe.is_none() {
-                    return Ok(());
-                }
-                let entry_notifier = entry_notifier_maybe.as_ref().unwrap();
-                // println!("___ Entry: {:?}", entry);
-                let entry_summary=solana_entry::entry::EntrySummary {
-                    num_hashes: _entry.num_hashes,
-                    hash: solana_hash::Hash::from(_entry.hash.to_bytes()),
-                    num_transactions: _entry.transactions.len() as u64,
-                };
-
-                let starting_transaction_index = 0; // TODO:: implement this
-                entry_notifier
-                    .notify_entry(block.slot, entry_index  ,&entry_summary, starting_transaction_index);
-                entry_index+=1;
-            }
-            node::Node::Block(_block) => {
-                // println!("___ Block: {:?}", block);
-                let notification = SlotNotification::Root((block.slot, block.meta.parent_slot));
-                confirmed_bank_sender.send(notification).unwrap();
-
-                {
-                    if block_meta_notifier_maybe.is_none() {
-                        return Ok(());
-                    }
-                    let mut keyed_rewards = Vec::with_capacity(this_block_rewards.rewards.len());
-                    {
-                        // convert this_block_rewards to rewards
-                        for this_block_reward in this_block_rewards.rewards.iter() {
-                            let reward: RewardInfo = RewardInfo{
-                                reward_type: match this_block_reward.reward_type {
-                                    0 => RewardType::Fee,
-                                    1 => RewardType::Rent,
-                                    2 => RewardType::Staking,
-                                    3 => RewardType::Voting,
-                                    _ => panic!("___ not supported reward type"),
-                                },
-                                lamports: this_block_reward.lamports,
-                                post_balance: this_block_reward.post_balance,
-                                // commission is Option<u8> , but this_block_reward.commission is string
-                                commission: match this_block_reward.commission.parse::<u8>() {
-                                    Ok(commission) => Some(commission),
-                                    Err(_err) => None,
-                                },
-                            };
-                            keyed_rewards.push((solana_pubkey::Pubkey::from_str(&this_block_reward.pubkey)?, reward));
-                        }
-                    }
-                    // if keyed_rewards.read().unwrap().len() > 0 {
-                    //   panic!("___ Rewards: {:?}", keyed_rewards.read().unwrap());
-                    // }
-                    let block_meta_notifier = block_meta_notifier_maybe.as_ref().unwrap();
-                    block_meta_notifier
-                        .notify_block_metadata(
-                            block.meta.parent_slot,
-                            todo_previous_blockhash.to_string().as_str(),
-                            block.slot,
-                            todo_latest_entry_blockhash.to_string().as_str(),
-                            &KeyedRewardsAndNumPartitions {
-                                keyed_rewards,
-                                num_partitions: None
-                            },
-                            Some(block.meta.blocktime as i64) ,
-                            block.meta.block_height,
-                            this_block_executed_transaction_count,
-                            this_block_entry_count,
-                        );
-                }
-                *todo_previous_blockhash = *todo_latest_entry_blockhash;
-            }
-            node::Node::Subset(_subset) => {
-                // println!("___ Subset: {:?}", subset);
-            }
-            node::Node::Epoch(epoch) => {
-                println!("___ Epoch: {:?}", epoch);
-            }
-            node::Node::Rewards(rewards) => {
-                // println!("___ Rewards: {:?}", node_with_cid.get_cid());
-                // println!("___ Next items: {:?}", rewards.data.next);
-
-                #[allow(clippy::overly_complex_bool_expr)]
-                if !rewards.is_complete() && false {
-                    let reassembled = nodes.reassemble_dataframes(rewards.data.clone())?;
-                    println!("___ reassembled: {:?}", reassembled.len());
-
-                    let decompressed = utils::decompress_zstd(reassembled)?;
-
-                    this_block_rewards = prost_011::Message::decode(decompressed.as_slice()).map_err(|err| {
-                        Box::new(std::io::Error::new(
-                            std::io::ErrorKind::Other,
-                            std::format!("Error decoding rewards: {:?}", err),
-                        ))
-                    })?;
-                }
-            }
-            node::Node::DataFrame(_) => {
-                // println!("___ DataFrame: {:?}", node_with_cid.get_cid());
-            }
-        }
-        Ok(())
-    })?;
-    
-    Ok(())
 }
 
 pub struct MessageAddressLoaderFromTxMeta {


### PR DESCRIPTION
### **User description**
To enhance error reporting in `geyser-plugin-runner/src/main.rs`:

*   A `latest_processed_block_number: Option<u64>` variable was introduced in `main` to track the slot of the last successfully processed block.
*   The core block processing logic was refactored into a new function, `process_block`, which takes a mutable reference to `latest_processed_block_number`.
*   Inside `process_block`, `*latest_processed_block_number = Some(block.slot);` is updated immediately after a block is successfully read, ensuring the variable always holds the most recent slot.
*   The `main` function now calls `process_block` within a `result` block.
*   Upon an error returned from `process_block`, the `main` function checks `latest_processed_block_number`. If a block number is available, it is printed to `eprintln!` along with the error details; otherwise, a message indicating no blocks were processed is printed.

These changes ensure that if an error occurs during node parsing, the last successfully processed block number is reported, aiding in debugging.


___

### **PR Type**
enhancement, error handling


___

### **Description**
- Introduced a new variable `latest_processed_block_number` to track the last successfully processed block, aiding in error reporting.
- Refactored the core block processing logic into a new function `process_block`, which updates the `latest_processed_block_number`.
- Enhanced error handling in the `main` function to log the latest processed block number when an error occurs, improving debugging capabilities.
- Wrapped the main processing logic in a `result` block to catch and handle errors effectively.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Refactor and enhance error handling in block processing</code>&nbsp; &nbsp; </dd></summary>
<hr>

geyser-plugin-runner/src/main.rs

<li>Introduced <code>latest_processed_block_number</code> to track the last <br>successfully processed block.<br> <li> Refactored block processing logic into a new function <code>process_block</code>.<br> <li> Enhanced error handling to log the latest processed block number on <br>failure.<br> <li> Updated <code>main</code> function to handle errors and print block numbers.<br>


</details>


  </td>
  <td><a href="https://github.com/kryptogo/yellowstone-faithful/pull/1/files#diff-9afa29a3a343c14009b3e02b5ca1fcfe7d5d368c29b87d465668889fa4c53f84">+218/-173</a></td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information